### PR TITLE
fix(profile): make mobile friendly

### DIFF
--- a/frontend/src/components/Profile.js
+++ b/frontend/src/components/Profile.js
@@ -126,7 +126,7 @@ class Profile extends React.Component {
     return (
       <div className="profile-page">
         <div className="container">
-          <div className="row p-4">
+          <div className="row p-4 text-center">
             <div className="user-info col-xs-12 col-md-8 offset-md-2">
               <img
                 src={profile.image}

--- a/frontend/src/components/Profile.js
+++ b/frontend/src/components/Profile.js
@@ -126,7 +126,7 @@ class Profile extends React.Component {
     return (
       <div className="profile-page">
         <div className="container">
-          <div className="row p-4 text-center">
+          <div className="row p-4">
             <div className="user-info col-xs-12 col-md-8 offset-md-2">
               <img
                 src={profile.image}

--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -55,7 +55,3 @@ body {
   display: -webkit-box;
   -webkit-box-orient: vertical;
 }
-
-.user-info {
-  min-width: 800px;
-}


### PR DESCRIPTION
# Description

Make the profile page more mobile friendly by removing the `text-center` class relationship. This was moving the profile content out of view.